### PR TITLE
Pass global dependencies to devDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This is a sample repository for React JSX with CSS Modules for TypeScript.
 ## install
 
 ```sh
-npm -g install typescript browserify typed-css-modules http-server
 npm install
 npm run build
 ```

--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "css-modulesify": "^0.16.1"
+    "browserify": "^13.1.1",
+    "css-modulesify": "^0.16.1",
+    "http-server": "^0.9.0",
+    "typed-css-modules": "^0.1.13",
+    "typescript": "^2.0.9"
   },
   "dependencies": {
     "react": "^0.14.6",


### PR DESCRIPTION
IMHO in this case it's preferable to avoid install global dependencies.
It removes an unnecessary step, and will not pollute global dependencies for something that is a Proof of Concept.